### PR TITLE
Change from iconv to iconv-lite

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -5,7 +5,8 @@ var http = require('http'),
     request = require('request'),
     _ = require('underscore'),
     jschardet = require('jschardet'),
-    Iconv = require('iconv').Iconv,
+    //Iconv = require('iconv').Iconv, <-- removing to test with iconv-lite
+    iconv = require('iconv-lite'), // <-- using iconv-lite instead of Iconv
     jsdom = require('jsdom'),
     Pool = require('generic-pool').Pool;
 
@@ -162,8 +163,14 @@ exports.Crawler = function(options) {
                     console.log("Detected charset "+detected.encoding+" ("+Math.floor(detected.confidence*100)+"% confidence)");
                 }
                 if (detected.encoding!="utf-8" && detected.encoding!="ascii") {
+                    /* --- Using iconv-lite instead..
                     var iconv = new Iconv(detected.encoding, "UTF-8//TRANSLIT//IGNORE");
                     response.body = iconv.convert(response.body).toString();
+                    */
+                    if (detected.encoding != "Big5") { // iconv-lite doesn't support Big5 (yet)
+                        response.body = iconv.decode(response.body, detected.encoding);
+                    }
+                    
                 } else if (typeof response.body != "string") {
                     response.body = response.body.toString();
                 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
        "htmlparser": "1.7.6",
        "underscore": "1.3.3",
        "jschardet": "1.0.2",
-       "iconv": "1.2.3"
+       "iconv-lite": "0.2.5"
     },
     "devDependencies": {
        "qunit": "0.5.8",


### PR DESCRIPTION
It seems that I'm not the only one having difficulties dealing with iconv.

Proposing change from iconv to iconv-lite (https://github.com/ashtuchkin/iconv-lite)

Benefits: 
- Cleaner code (one liner)
- Quicker conversion (though shouldn't be an issue anyway I'd think)

Drawbacks:
- Doesn't support 'Big5' charset (chinese)
- Also doesn't support: "EUC family, Shift_JIS." (as quoted from readme.md).

I don't believe the EUC family nor Shift_JIS will be likely to be encountered on the net, though Big5 /might/ be somewhat annoying for those crawling the east (I really don't know how widespread this is anyway).  In any event, this will make deployments that much easier as it doesn't have any deeper platform requirements.
- Note: I've been trying to test it fully - got everything except 'errors.js' passing on cloud9 and centos 6 with nodejs 6.x and 8.x respectively, though got an error in 'forceutf8.js' when testing on windows.  I'm thinking there's something related to catching invalid responses (each time it's 'cannot read property 'body' of undefined' errors).  Worth checking out thouth I'd say.
