### PR TITLE
Bumped the JSDOM version in order to fix memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ,
     "dependencies": {
        "request": "2.11.1",
-       "jsdom": "0.2.15",
+       "jsdom": "0.2.19",
        "generic-pool": "2.0.1",
        "htmlparser": "1.7.6",
        "underscore": "1.3.3",


### PR DESCRIPTION
The memory usage would just grow and grow prior to this change.  I'd love to get this npm published if possible.

There is one sideeffect.  They changed the way the path evaluates on windows which effects the a.href value in the DOM.  Now it appears as file:///C:/path/to/file
