### PR TITLE
The sample code in readme.md had a little mistake in its $.each call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Crash course
         "callback":function(error,result,$) {
 
             // $ is a jQuery instance scoped to the server-side DOM of the page
-            $("#content a").each(function(a) {
+            $("#content a").each(function(index,a) {
                 c.queue(a.href);
             });
         }


### PR DESCRIPTION
I was trying to run a crawler based on the sample code in readme.md, but kept running into weird callback problems and code not executing. It turns out the example code in the readme wasn't quite passing enough arguments to get the expected behaviour out of $.each. I've fixed it so that the example now runs as intended.
