### PR TITLE
fix for jsdom crawler crash

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -275,7 +275,12 @@ exports.Crawler = function(options) {
                             toQueue.callback(e);
                             release(toQueue);
                         } else {
-                            jsd([jq]);
+                            try {
+                                jsd([jq]);
+                            } catch (e) {
+                                toQueue.callback(e);
+                                release(toQueue);
+                            }
                         }
                     });
                 } else {


### PR DESCRIPTION
Fixed a problem with crawler crash when jsdom initializes asynchronously causing an uncaught exception.
