### PR TITLE
Let `options.encoding = null` be really null (it should not accept `gzip`)

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -129,7 +129,7 @@ exports.Crawler = function(options) {
             if (!ropts.headers["Accept-Charset"] && !ropts.headers["accept-charset"]) ropts.headers["Accept-Charset"] = 'utf-8;q=0.7,*;q=0.3';
             if (!ropts.encoding) ropts.encoding=null;
         }
-        if (!ropts.encoding) {
+        if (typeof ropts.encoding === 'undefined') {
             ropts.headers["Accept-Encoding"] = "gzip";
             ropts.encoding = null;
         }


### PR DESCRIPTION
then I can set `options.encoding` to `null`.
Here's quote from **request**:
`encoding` - Encoding to be used on `setEncoding` of response data. If set to `null`, the body is returned as a Buffer.
