### PR TITLE
fixing the typo in the tests link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ c.queue([{
     html: '<p>This is a <strong>test</strong></p>'
 }]);
 ```
-For more examples, look at the [tests](https://github.com/sylvinus/node-crawler/tree/master/test).
+For more examples, look at the [tests](https://github.com/sylvinus/node-crawler/tree/master/tests).
 
 Options reference
 -----------------


### PR DESCRIPTION
Hi. I just noticed this link wasn't working properly.
