### PR TITLE
option to restric to certain hostnames

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -227,7 +227,7 @@ Crawler.prototype._pushToQueue = function _pushToQueue (options) {
     }
 
     // If duplicate skipping is enabled, avoid queueing entirely for URLs we already crawled
-    if ((options.skipDuplicates && self.cache[options.uri]) || (options.authorizedDomain && options.uri.indexOf(options.authorizedDomain) === -1)) {
+    if (options.skipDuplicates && self.cache[options.uri]) {
         return self.emit('pool:release', options);
     }
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
+var url = require('url');
 
 var request = require('request');
 var _ = require('lodash');
@@ -73,7 +74,8 @@ Crawler.prototype.init = function init (options) {
         referer:            false,
         retries:            3,
         retryTimeout:       10000,
-        skipDuplicates:     false
+        skipDuplicates:     false,
+        authorizedHostnames: []
     };
 
     //return defaultOptions with overriden properties from options.
@@ -217,8 +219,15 @@ Crawler.prototype._pushToQueue = function _pushToQueue (options) {
         delete options[globalOnlyOption];
     });
 
+    // Check if url hostname is authorized
+    var hostname = url.parse(options.uri).hostname;
+    if (!(_.isArray(options.authorizedHostnames) && _.contains(options.authorizedHostnames, hostname))
+        && !(_.isString(options.authorizedHostnames) && options.authorizedHostnames === hostname)) {
+        return self.emit('pool:release', options);
+    }
+
     // If duplicate skipping is enabled, avoid queueing entirely for URLs we already crawled
-    if (options.skipDuplicates && self.cache[options.uri]) {
+    if ((options.skipDuplicates && self.cache[options.uri]) || (options.authorizedDomain && options.uri.indexOf(options.authorizedDomain) === -1)) {
         return self.emit('pool:release', options);
     }
 


### PR DESCRIPTION
When automatically adding links to the queue you don't necessarily want to crawl other websites.

I have added a simple option "authorizedHostnames" that can be a string or array of string with the hostname that you want to crawl and will automatically remove link that doesn't match.

ex: 
With the following code you will soon enough be crawling twitter

``` javascript

var c = new Crawler({
    callback: function (error, result, $) {
        $('a').each(function (index, a) {
            var toQueueUrl = $(a).attr('href');
            c.queue(toQueueUrl);
        });
    }
});
c.queue('http://www.joshfire.com')
```

Just adding the option will restric to joshfire website

``` javascript

var c = new Crawler({
     authorizedHostnames: 'joshfire.com',
    callback: function (error, result, $) {
        $('a').each(function (index, a) {
            var toQueueUrl = $(a).attr('href');
            c.queue(toQueueUrl);
        });
    }
});
c.queue('http://www.joshfire.com')
```
