### PR TITLE
Fix: skipDuplicates doesn't work when duplicate links on same page

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -105,6 +105,7 @@ Crawler.prototype.init = function init (options) {
     self.queueItemSize = 0;
 
     self.cache = {};
+    self.history = {};
 
     self.on('pool:release', function(options) {
         self._release(options);
@@ -204,7 +205,6 @@ Crawler.prototype.queue = function queue (options) {
 
 Crawler.prototype._pushToQueue = function _pushToQueue (options) {
     var self = this;
-    self.queueItemSize++;
 
     // you can use jquery or jQuery
     options = checkJQueryNaming(options);
@@ -218,9 +218,11 @@ Crawler.prototype._pushToQueue = function _pushToQueue (options) {
     });
 
     // If duplicate skipping is enabled, avoid queueing entirely for URLs we already crawled
-    if (options.skipDuplicates && self.cache[options.uri]) {
-        return self.emit('pool:release', options);
+    if (options.skipDuplicates && self.history[options.uri]) {
+      return;
     }
+    self.queueItemSize++;
+    self.history[options.uri] = true;
 
     // acquire connection - callback function is called
     // once a resource becomes available
@@ -257,7 +259,7 @@ Crawler.prototype._makeCrawlerRequest = function _makeCrawlerRequest (options) {
         }, options.rateLimits);
     } else {
         self._executeCrawlerRequest(options);
-    }    
+    }
 };
 
 Crawler.prototype._executeCrawlerRequest = function _executeCrawlerRequest (options) {
@@ -274,7 +276,7 @@ Crawler.prototype._executeCrawlerRequest = function _executeCrawlerRequest (opti
         } else {
             self.emit('pool:release', options);
         }
-        
+
     } else {
         self._buildHttpRequest(options);
     }

--- a/tests/skipDuplicates.test.js
+++ b/tests/skipDuplicates.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var Crawler = require('../lib/crawler');
+var expect = require('chai').expect;
+var c, s;
+var http = require('http');
+
+describe('skip duplicates', function() {
+  beforeEach(function() {
+    var server = http.createServer(function (req, res) {
+      res.end('<html><a href="http://github.com">a</a> <a href="http://github.com">b</a></html>');
+    });
+
+    server.listen();
+    s = server.address();
+
+    c = new Crawler({
+      skipDuplicates: true
+    });
+  });
+  it('should not queue the same link', function(done) {
+    c.queue({
+      uri : 'http://'+s.address+':'+s.port,
+      callback: function(error, result, $) {
+        $('a').each(function(i,a) {
+          c.queue($(a).attr('href'));
+        });
+        // the link currently processing plus the one added
+        // if both links are added, queueItemSize will be 3
+        expect(c.queueItemSize).to.equal(2);
+        done();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Skip duplicates does not work when same link is added with very short delay (as cache isn't ready). This PR adds a property called history, to keep track of which pages has been added. Test is also added.
