### PR TITLE
Fixed Cookie Jar -- need to be passed as object to request

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -295,6 +295,11 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
 
     var ropts = JSON.parse(JSON.stringify(options));
 
+    // Restore Cookie Jar object after cloning (otherwice cookie jar will not work)
+    if (options.jar) {
+        ropts.jar = options.jar;
+    }
+
     if (!ropts.headers) { ropts.headers={}; }
     if (ropts.forceUTF8) {
         if (!ropts.headers['Accept-Charset'] && !ropts.headers['accept-charset']) {
@@ -317,6 +322,7 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
     if (ropts.proxies && ropts.proxies.length) {
         ropts.proxy = ropts.proxies[0];
     }
+
 
     var requestArgs = ['uri','url','qs','method','headers','body','form','json','multipart','followRedirect',
         'followAllRedirects', 'maxRedirects','encoding','pool','timeout','proxy','auth','oauth','strictSSL',


### PR DESCRIPTION
Passing Cookie Jar to request via the jar argument has not been working because of conversion of the jar object residing inside the options object to a string:
    var ropts = JSON.parse(JSON.stringify(options));

The Jar need to be saved across the requests and therefore cannot be 'cloned' this way.
It was resolved by restoring the original jar object back after the cloning operation.