### PR TITLE
Remove filtering options for request call

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -317,12 +317,7 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
         ropts.proxy = ropts.proxies[0];
     }
 
-    var requestArgs = ['uri','url','qs','method','headers','body','form','json','multipart','followRedirect',
-        'followAllRedirects', 'maxRedirects','encoding','pool','timeout','proxy','auth','oauth','strictSSL',
-        'jar','aws'];
-
-
-    var req = request(_.pick.apply(this,[ropts].concat(requestArgs)), function(error,response) {
+    var req = request(ropts, function(error,response) {
         if (error) {
             return self._onContent(error, options);
         }


### PR DESCRIPTION
This fixes #155.  I removed the filtering of options passed to request(), should make things easier.
