### PR TITLE
Fix handling of followRedirect when it's a function

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -264,10 +264,9 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
     // - some versions of "request" apply the second parameter as a
     // property called "callback" to the first parameter
     // - keeps the query object fresh in case of a retry
-    // Doing parse/stringify instead of _.clone will do a deep clone and remove functions
     
     self._deleteEntity(options);
-    var ropts = JSON.parse(JSON.stringify(options));
+    var ropts = _.cloneDeep(options);
     self._attachEntity(ropts);
     
     if (!ropts.headers) { ropts.headers={}; }


### PR DESCRIPTION
Replace stringify/parse with lodash.cloneDeep().  This has the benefit
of preserving functions, which is necessary because request's
`followRedirect` can be a function.