### PR TITLE
Allow options to specify the Agent for Request

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -331,7 +331,7 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
 
 	var requestArgs = ['uri','url','qs','method','headers','body','form','json','multipart','followRedirect',
 			   'followAllRedirects', 'maxRedirects','encoding','pool','timeout','proxy','auth','oauth','strictSSL',
-			   'jar','aws','gzip','time','tunnel','proxyHeaderWhiteList','proxyHeaderExclusiveList','localAddress','forever'];
+			   'jar','aws','gzip','time','tunnel','proxyHeaderWhiteList','proxyHeaderExclusiveList','localAddress','forever', 'agent'];
 
 	request(_.pick.apply(self,[ropts].concat(requestArgs)), function(error,response) {
             if (error) {


### PR DESCRIPTION
Allow constructor options to specify an agent property to mikeal's request, allowing for the use of modules such as socks5-http-client.