### PR TITLE
fix the ";" problem in content-type of type-is

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -43,7 +43,7 @@ function readJqueryUrl (url, callback) {
 }
 
 function contentType(res){
-    return get(res,'content-type').split(';').filter(item => { return item.length !== 0; }).join(';');
+    return get(res,'content-type').split(';').filter(item => item.trim().length !== 0).join(';');
 }
 
 function get(res,field){

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -43,7 +43,7 @@ function readJqueryUrl (url, callback) {
 }
 
 function contentType(res){
-    return get(res,'content-type');
+    return get(res,'content-type').split(';').filter(item => { return item.length !== 0; }).join(';');
 }
 
 function get(res,field){


### PR DESCRIPTION
```
> i='csdcvv;;dvsdvm;dsfdvmsd'
'csdcvv;;dvsdvm;dsfdvmsd'
> j=i.split(';').filter(item => { return item.length !== 0; }).join(';');
'csdcvv;dvsdvm;dsfdvmsd'
> i='sdv;'
'sdv;'
> j=i.split(';').filter(item => { return item.length !== 0; }).join(';');
'sdv'
> i='ewf;ewfw'
'ewf;ewfw'
> j=i.split(';').filter(item => { return item.length !== 0; }).join(';');
'ewf;ewfw'
```