### PR TITLE
chore(gzip) Retry without gzip when response seems broken

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -333,13 +333,25 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
 			   'followAllRedirects', 'maxRedirects','encoding','pool','timeout','proxy','auth','oauth','strictSSL',
 			   'jar','aws','gzip','time','tunnel','proxyHeaderWhiteList','proxyHeaderExclusiveList','localAddress','forever', 'agent'];
 
-	request(_.pick.apply(self,[ropts].concat(requestArgs)), function(error,response) {
-            if (error) {
-		return self._onContent(error, options);
-            }
-	    
-            self._onContent(error,options,response);
-	});
+  function tryWithOptions(requestOptions, onError) {
+      request(requestOptions, function(error, response) {
+          if (!error) {
+              return self._onContent(error, options, response);
+          }
+          onError(error);
+      });
+  }
+
+  var allRequestOptions = _.pick.apply(self,[ropts].concat(requestArgs));
+  tryWithOptions(allRequestOptions, function(error) {
+      if (error.code === 'Z_DATA_ERROR') {
+          tryWithOptions(_.assign(allRequestOptions, {gzip: false}), function(newError) {
+              return self._onContent(newError, options);
+          });
+      } else {
+          self._onContent(error, options);
+      }
+  });
     }
 
     if (options.preRequest && _.isFunction(options.preRequest)) {


### PR DESCRIPTION
Hello,

Sometimes servers return broken gzipped data.
We could try to fetch the webpage again as non-gzipped to get the content.