### PR TITLE
fix #261

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -211,7 +211,7 @@ Crawler.prototype.direct = function direct (options) {
 	self._buildHttpRequest(options);
 };
 
-Crawler.prototype.queue = function queue (options) {
+Crawler.prototype.queue = function queue (options, force) {
 	var self = this;
 
 	// Did you get a single object or string? Make it compatible.
@@ -225,12 +225,12 @@ Crawler.prototype.queue = function queue (options) {
 			continue;
 		}
 		self._pushToQueue(
-			_.isString(options[i]) ? {uri: options[i]} : options[i]
+			_.isString(options[i]) ? {uri: options[i]} : options[i], force
 		);
 	}
 };
 
-Crawler.prototype._pushToQueue = function _pushToQueue (options) {
+Crawler.prototype._pushToQueue = function _pushToQueue (options, force) {
 	var self = this;
 
 	// you can use jquery or jQuery
@@ -244,7 +244,7 @@ Crawler.prototype._pushToQueue = function _pushToQueue (options) {
 	self.globalOnlyOptions.forEach(globalOnlyOption => delete options[globalOnlyOption]);
 
 	// If duplicate skipping is enabled, avoid queueing entirely for URLs we already crawled
-	if (self.options.skipDuplicates && self.seen.exists(options, options.seenreq)) {
+	if (self.options.skipDuplicates && self.seen.exists(options, options.seenreq) && force !== true) {
 		return;
 	}
 
@@ -352,10 +352,9 @@ Crawler.prototype._onContent = function _onContent (error, options, response) {
 		log('error','Error '+error+' when fetching '+ (options.uri||options.url)+(options.retries ? ' ('+options.retries+' retries left)' : ''));
 
 		if (options.retries) {
-			self.options.skipDuplicates = false;
 			setTimeout(function() {
 				options.retries--;
-				self.queue(options);
+				self.queue(options, true);
 				options.release();
 			},options.retryTimeout);
 		} else{


### PR DESCRIPTION
Description:
If you add some URLs to the queue and skipDuplicates is set to false. After one of this fails skipDuplicates will be set to false. This should not happen, in case of error.

Changes:
* remove 'skipDuplicates = false' on error
* add a force to queue paramater