### PR TITLE
#comment Adding support for Https socks5. Agent is imported directly …

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,31 @@ the request() method.
  * `options.removeRefererHeader`: [Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type) If true preserves the set referer during redirects
  * `options.headers`: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) Raw key-value of http headers
 
+### Https socks5 
+```js
+const Agent = require('socks5-https-client/lib/Agent');
+//...
+var c = new Crawler({
+    // rateLimit: 2000,
+    maxConnections: 20,
+    agentClass: true, //adding socks5 https agent
+    method: 'GET',
+    strictSSL: true,
+    agentOptions: {
+        socksHost: 'localhost',
+        socksPort: 9050
+    },
+    // debug: true,
+    callback: function (error, res, done) {
+        if (error) {
+            console.log(error);
+        } else {
+            //
+        }
+        done();
+    }
+}); 
+```
 
 
 ## Work with Cheerio or JSDOM

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ const Agent = require('socks5-https-client/lib/Agent');
 var c = new Crawler({
     // rateLimit: 2000,
     maxConnections: 20,
-    agentClass: true, //adding socks5 https agent
+    agentClass: Agent, //adding socks5 https agent
     method: 'GET',
     strictSSL: true,
     agentOptions: {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -11,7 +11,8 @@ var path = require('path')
 	, Bottleneck = require('bottleneckp')
 	, seenreq = require('seenreq')
 	, iconvLite = require('iconv-lite')
-	, typeis = require('type-is').is;
+	, typeis = require('type-is').is
+	, httpsAgent = require('socks5-https-client/lib/Agent');
 
 var whacko=null, level, levels = ['silly','debug','verbose','info','warn','error','critical'];
 try{
@@ -109,7 +110,7 @@ Crawler.prototype.init = function init (options) {
 
 	self.seen = new seenreq(self.options.seenreq);
 	self.seen.initialize().then(()=> log('debug', 'seenreq is initialized.')).catch(e => log('error', e));
-	
+
 	self.on('_release', function(){
 		log('debug','Queue size: %d',this.queueSize);
 
@@ -324,6 +325,9 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
 		ropts.proxy = ropts.proxies[0];
 	}
 
+	if (ropts.agentClass) {
+		ropts.agentClass = httpsAgent;
+	}
 	var doRequest = function(err) {
 		if(err) {
 			err.message = 'Error in preRequest' + (err.message ? ', '+err.message : err.message);
@@ -341,7 +345,7 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
 			self.emit('request',ropts);
 		}
 
-		var requestArgs = ['uri','url','qs','method','headers','body','form','formData','json','multipart','followRedirect','followAllRedirects','maxRedirects','removeRefererHeader','encoding','pool','timeout','proxy','auth','oauth','strictSSL','jar','aws','gzip','time','tunnel','proxyHeaderWhiteList','proxyHeaderExclusiveList','localAddress','forever', 'agent'];
+		var requestArgs = ['uri','url','qs','method','headers','body','form','formData','json','multipart','followRedirect','followAllRedirects','maxRedirects','removeRefererHeader','encoding','pool','timeout','proxy','auth','oauth','strictSSL','jar','aws','gzip','time','tunnel','proxyHeaderWhiteList','proxyHeaderExclusiveList','localAddress','forever', 'agent', 'strictSSL', 'agentOptions', 'agentClass'];
 
 		request(_.pick.apply(self,[ropts].concat(requestArgs)), function(error,response) {
 			if (error) {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -11,8 +11,7 @@ var path = require('path')
 	, Bottleneck = require('bottleneckp')
 	, seenreq = require('seenreq')
 	, iconvLite = require('iconv-lite')
-	, typeis = require('type-is').is
-	, httpsAgent = require('socks5-https-client/lib/Agent');
+	, typeis = require('type-is').is;
 
 var whacko=null, level, levels = ['silly','debug','verbose','info','warn','error','critical'];
 try{
@@ -325,9 +324,6 @@ Crawler.prototype._buildHttpRequest = function _buildHTTPRequest (options) {
 		ropts.proxy = ropts.proxies[0];
 	}
 
-	if (ropts.agentClass) {
-		ropts.agentClass = httpsAgent;
-	}
 	var doRequest = function(err) {
 		if(err) {
 			err.message = 'Error in preRequest' + (err.message ? ', '+err.message : err.message);


### PR DESCRIPTION
…in crawler.js. Extended allowed fields for request object.

```js
const Agent = require('socks5-https-client/lib/Agent');
//...
var c = new Crawler({
    // rateLimit: 2000,
    maxConnections: 20,
    agentClass: true, //adding socks5 https agent
    method: 'GET',
    strictSSL: true,
    agentOptions: {
        socksHost: 'localhost',
        socksPort: 9050
    },
    // debug: true,
    callback: function (error, res, done) {
        if (error) {
            console.log(error);
        } else {
            //
        }
        done();
    }
});
```