### PR TITLE
Fixes uncatchable error when connection is retried

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -552,7 +552,6 @@ Crawler.prototype._onContent = function _onContent(error, options, response) {
 					self._schedule(options);
 					options.release();
 				}, options.retryTimeout);
-				return;
 			}
 			break;
 		}


### PR DESCRIPTION
If an error is passed to _onContent, but options.retries value is true the _onContent function was being prematurely returned before passing the error to options.callback causing an uncatchable error.