### PR TITLE
if set json params must to json object

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -574,6 +574,11 @@ Crawler.prototype._onContent = function _onContent(error, options, response) {
 
 	response.options = options;
 
+	// if set json params must to json object
+	if(options.html && options.json){
+		response.body = JSON.parse(response.body)
+	}
+
 	if (options.method === 'HEAD' || !options.jQuery) {
 		return options.callback(null, response, options.release);
 	}


### PR DESCRIPTION
如果c.queue( {json:true,html:"{jsonxxxxxxxx}"})
则返回就必须个json object